### PR TITLE
Update docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,39 +11,74 @@ on:
       - main
 
 jobs:
+
+  # build the documentation
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Set up Python  # use uv to install Python
+      run: uv python install
+
+    - name: Install superneuromat
       run: |
-        python3 -m pip install --upgrade pip
-        pip install .[doc]
+        uv venv venv
+        . venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+        uv pip install .[doc]
+        echo $PATH
+      # note: need to modify GITHUB_ENV path for the new venv to be used
+      # as each run step is a new shell
     - name: List src directory for debugging
       run: |
          ls -R src
+         echo $PATH
     - name: Verify installation
       run: |
-        pip show SimLogger
+        uv pip show SimLogger
     - name: Build HTML
       run: |
         cd docs
         make html
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-pages-artifact@v3
+      id: deployment
       with:
-        name: html-docs
+        name: github-pages
         path: docs/build/html/
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+    # - name: Deploy
+    #   uses: peaceiris/actions-gh-pages@v3
+    #   if: github.ref == 'refs/heads/main'
+    #   with:
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+    #     publish_dir: docs/build/html
+
+  # Deploy job
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+    if: github.ref == 'refs/heads/main'
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
pushing to main will build/deploy docs without creating a separate branch. Also uses uv for fast setup of dependencies. Note that deployment is skipped for tags, as the github environment permissions are for main branch only (by default)